### PR TITLE
Add additional init configuration

### DIFF
--- a/pages/translate/keyBasedFallback/index.jsx
+++ b/pages/translate/keyBasedFallback/index.jsx
@@ -43,7 +43,8 @@ i18next is flexible enough to be used this way, you should init i18next with:
 
     i18next.init({
       nsSeparator: false,
-      keySeparator: false
+      keySeparator: false,
+      fallbackLng: false
     });
 
 Further using [sprintf post processor](../../docs/ecosystem/#postprocessors) enables sprintf.


### PR DESCRIPTION
According to [this issue](https://github.com/i18next/i18next/issues/658), `fallbackLng` should be set to false.  Doing that worked for me, and seems like a necessary thing for `gettext`?